### PR TITLE
Fixed issue when printing in IE11

### DIFF
--- a/jQuery.print.js
+++ b/jQuery.print.js
@@ -128,7 +128,11 @@
                 setTimeout(function() {
                     // Fix for IE : Allow it to render the iframe
                     w.focus();
-                    w.print();
+                    try {
+                        w.document.execCommand('print', false, null);
+                    } catch(e) {
+                        w.print();
+                    }
                     setTimeout(function() {
                         // Fix for IE
                         if (iframeCount === 0) {


### PR DESCRIPTION
Printing in IE11 caused the whole page to be printed, not just the content in the iframe. This change should fix the issue :-)
