### PR TITLE
Allow custom title

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can submit the options object like:
         	prepend: null,
         	manuallyCopyFormValues: true,
         	deferred: $.Deferred(),
-        	timeout: 250
+        	timeout: 250,
+        	title: null
 	});
 ```
 
@@ -95,6 +96,11 @@ Currently this plugin supports the following options:
  - Acceptable-Values: Time in Milliseconds for `setTimeout`
  - Function: To change the amount of time to wait for the content, etc to load before printing the element from the new window/iframe created
  
+####title
+
+ - Default: `null`, uses the host page title
+ - Acceptable-Values: Any single-line string
+ - Function: To change the printed title
  
 ## Tested with
 

--- a/jQuery.print.js
+++ b/jQuery.print.js
@@ -100,7 +100,8 @@
             prepend: null,
             manuallyCopyFormValues: true,
             deferred: $.Deferred(),
-            timeout: 250
+            timeout: 250,
+            title: null
         };
         // Merge with user-options
         options = $.extend({}, defaults, (options || {}));
@@ -126,6 +127,15 @@
             .remove();
         // Add in the styles
         copy.append($styles.clone());
+        // Update title
+        if (options.title) {
+            var title = $("title", copy);
+            if (title.length === 0) {
+                title = $("<title />");
+                copy.append(title);                
+            }
+            title.text(options.title);            
+        }
         // Appedned content
         copy.append(getjQueryObject(options.append));
         // Prepended content


### PR DESCRIPTION
Currently the element is printed with the same title as the page.  Adding an ability to specify a custom title to override the page title on printing.  Works with iframe mode (the default) on IE 11 and Chrome.  Haven't tested other scenarios.