### PR TITLE
fix strict mode error

### DIFF
--- a/jQuery.print.js
+++ b/jQuery.print.js
@@ -31,7 +31,7 @@
             wdoc.write(content);
             wdoc.close();
             var printed = false;
-            function callPrint() {
+            var callPrint = function () {
                 if(printed) {
                     return;
                 }


### PR DESCRIPTION
When using Safari 8 I get the following error:
**strict mode does not allow function declarations in a lexically nested statement**

This commit preserves 'use strict',  tested on Safari 8 and Safari 10.

Source:
http://eslint.org/docs/rules/no-inner-declarations