### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,67 +43,67 @@ You can submit the options object like:
 
 Currently this plugin supports the following options:
 
-####globalStyles
+#### globalStyles
 
  - Default: `true`  
  - Acceptable-Values: Boolean  
  - Function: Whether or not the styles from the parent document should be included
 
-####mediaPrint
+#### mediaPrint
 
  - Default: `false`  
  - Acceptable-Values: Boolean  
  - Function: Whether or not link tags with media='print' should be included; Over-riden by the `globalStyles` option
 
-####stylesheet
+#### stylesheet
 
  - Default: `null`
  - Acceptable-Values: URL-string
  - Function: URL of an external stylesheet to be included
 
-####noPrintSelector
+#### noPrintSelector
 
  - Default: `".no-print"`
  - Acceptable-Values: Any valid `jQuery-selector`
  - Function: A selector for the items that are to be excluded from printing
 
-####iframe
+#### iframe
 
  - Default: `true`, creates a hidden iframe if no-vaild iframe selector is passed
  - Acceptable-Values: Any valid `jQuery-selector` or Boolean
  - Function: Whether to print from an iframe instead of a pop-up window; can take the `jQuery-selector` of an existing iframe as value
 
-####append/prepend
+#### append/prepend
 
  - Default: `null`
  - Acceptable-Values: Any valid `jQuery-selector` or HTML-text
  - Function: Adds custom HTML before (prepend) or after (append) the selected content
 
-####manuallyCopyFormValues
+#### manuallyCopyFormValues
 
  - Default: `true`
  - Acceptable-Values: Boolean
  - Function: Should it copy user-updated form input values onto the printed markup (this is done by manually iterating over each form element)
 
-####deferred
+#### deferred
 
  - Default: `$.Deferred()`
  - Acceptable-Values: Any valid `jQuery.Deferred` object
  - Function: A jQuery.Deferred object that is resolved once the print function is called. Can be used [to setup callbacks - see wiki](https://github.com/DoersGuild/jQuery.print/wiki/Using-the-deferred-option-to-set-up-a-callback-after-printing)
 
-####timeout
+#### timeout
 
  - Default: `750`
  - Acceptable-Values: Time in Milliseconds for `setTimeout`
  - Function: To change the amount of max time to wait for the content, etc to load before printing the element from the new window/iframe created, as a fallback if the [`load` event](https://developer.mozilla.org/en-US/docs/Web/Events/load) for the new window/iframe has not fired yet
  
-####title
+#### title
 
  - Default: `null`, uses the host page title
  - Acceptable-Values: Any single-line string
  - Function: To change the printed title
 
-####doctype
+#### doctype
 
  - Default: `'<!doctype html>'`
  - Acceptable-Values: Any valid doctype string


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
